### PR TITLE
Update Dockerfile to use --legacy-peer-deps for client npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:16-alpine AS client-builder
 WORKDIR /app
 COPY client/package*.json ./
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 COPY client/ ./
 RUN npm run build
 


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change modifies the npm install command to use the `--legacy-peer-deps` flag temporarily for the client build, ensuring compatibility with older peer dependencies.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-R5): Modified the `RUN npm ci` command to `RUN npm ci --legacy-peer-deps` to resolve dependency issues.